### PR TITLE
Various Portability Fixes

### DIFF
--- a/Randomization_Processes/Clean_Up.py
+++ b/Randomization_Processes/Clean_Up.py
@@ -23,7 +23,7 @@ class CleanUp():
     
     def _remove_bin_files(self, it_errored=False):
         """Removes compressed and decompressed bin files created during the randomization"""
-        randomized_rom_dir = f"{self._file_dir}Randomized_ROM\\"
+        randomized_rom_dir = f"{self._file_dir}Randomized_ROM/"
         for filename in os.listdir(randomized_rom_dir):
             file_path = os.path.join(randomized_rom_dir, filename)
             try:

--- a/Randomization_Processes/Compress_Functions.py
+++ b/Randomization_Processes/Compress_Functions.py
@@ -143,7 +143,10 @@ class Compressor():
 
     def _compress_file(self, file_name):
         '''Compresses the hex file that was extracted from the main ROM file'''
-        cmd = f"\"{self._file_dir}GZIP.EXE\" -c \"{self._file_dir}Randomized_ROM/{file_name.upper()}-Decompressed.bin\" > \"{self._file_dir}Randomized_ROM/{file_name.upper()}-New_Compressed.bin\""
+        if os.name == 'nt':
+            cmd = f"\"{self._file_dir}GZIP.EXE\" -c \"{self._file_dir}Randomized_ROM/{file_name.upper()}-Decompressed.bin\" > \"{self._file_dir}Randomized_ROM/{file_name.upper()}-New_Compressed.bin\""
+        else:
+            cmd = f"gzip -c \"{self._file_dir}Randomized_ROM/{file_name.upper()}-Decompressed.bin\" > \"{self._file_dir}Randomized_ROM/{file_name.upper()}-New_Compressed.bin\""
         subprocess.Popen(cmd, universal_newlines=True, shell=True).communicate()
     
     def _post_compress_operations(self, file_name, header, footer, decomp_len, padding_text="AA"):

--- a/Randomization_Processes/Compress_Functions.py
+++ b/Randomization_Processes/Compress_Functions.py
@@ -172,13 +172,13 @@ class Compressor():
     
     def _insert_into_rom_by_pointer(self, setup_pointer_start, setup_pointer_end, additional_skip_these_pointer_list=[]):
         for index_dec in range(setup_pointer_start, setup_pointer_end + 1, 8):
-            with open(f"{self._file_dir}Randomized_ROM\\Banjo-Kazooie_Randomized_Seed_{self._seed_val}.z64", "r+b") as bk_rom:
+            with open(f"{self._file_dir}Randomized_ROM/Banjo-Kazooie_Randomized_Seed_{self._seed_val}.z64", "r+b") as bk_rom:
                 mm_bk_rom = mmap(bk_rom.fileno(), 0)
                 index_hex_str = str(hex(index_dec))[2:]
                 if(index_hex_str in additional_skip_these_pointer_list):
                     self.skip_this_setup(mm_bk_rom, index_dec)
                 else:
-                    with open(f"{self._file_dir}Randomized_ROM\\{index_hex_str}-Randomized_Compressed.bin", "r+b") as setup_bin:
+                    with open(f"{self._file_dir}Randomized_ROM/{index_hex_str}-Randomized_Compressed.bin", "r+b") as setup_bin:
                         setup_content = setup_bin.read()
                         # Find The Pointer Start
                         pointer_start = ""
@@ -203,7 +203,7 @@ class Compressor():
         for offset in range(4):
             pointer_start += leading_zeros(mm_bk_rom[setup_pointer_end + 8 + offset], 2)
         address_next_start = int(f"0x{pointer_start}", 16) + int("0x10CD0", 16)
-        with open(f"{self._file_dir}Randomized_ROM\\Banjo-Kazooie_Randomized_Seed_{self._seed_val}.z64", "r+b") as bk_rom:
+        with open(f"{self._file_dir}Randomized_ROM/Banjo-Kazooie_Randomized_Seed_{self._seed_val}.z64", "r+b") as bk_rom:
             mm_bk_rom = mmap(bk_rom.fileno(), 0)
             for index in range(address_start + len(setup_content), address_next_start):
                 mm_bk_rom[index] = 0xAA
@@ -252,7 +252,7 @@ class Compressor():
                 mm[index] = 0
     
     def _verify_pointer_header(self, setup_pointer_start, setup_pointer_end):
-        with open(f"{self._file_dir}Randomized_ROM\\Banjo-Kazooie_Randomized_Seed_{self._seed_val}.z64", "r+b") as bk_rom:
+        with open(f"{self._file_dir}Randomized_ROM/Banjo-Kazooie_Randomized_Seed_{self._seed_val}.z64", "r+b") as bk_rom:
             mm_bk_rom = mmap(bk_rom.fileno(), 0)
             for pointer_index in range(setup_pointer_start, setup_pointer_end + 1, 8):
                 address_start = int((leading_zeros(mm_bk_rom[pointer_index], 2) +

--- a/Randomization_Processes/Decompress_Functions.py
+++ b/Randomization_Processes/Decompress_Functions.py
@@ -78,7 +78,7 @@ class Decompressor():
                     file_pointer = addr.split(",")[0]
                 self._verify_original_header(self._file_bytes, address1)
                 # Write Compressed File
-                with open(f"{self._file_dir}Randomized_ROM\\{file_pointer}-Compressed.bin", "w+b") as comp_file:
+                with open(f"{self._file_dir}Randomized_ROM/{file_pointer}-Compressed.bin", "w+b") as comp_file:
                     # Write Header
                     for hex_val in header:
                         comp_file.write(bytes.fromhex(hex_val))

--- a/Randomization_Processes/Decompress_Functions.py
+++ b/Randomization_Processes/Decompress_Functions.py
@@ -28,6 +28,7 @@ Created on Aug 24, 2021
 ######################
 
 import subprocess
+import os
 
 ####################
 ### FILE IMPORTS ###
@@ -57,7 +58,10 @@ class Decompressor():
     
     def _decompress_file(self, compressed_file):
         """Decompresses the hex file that was extracted from the main ROM file"""
-        cmd = f"\"{self._file_dir}GZIP.EXE\" -dc \"{self._file_dir}Randomized_ROM/{compressed_file.upper()}-Compressed.bin\" > \"{self._file_dir}Randomized_ROM/{compressed_file.upper()}-Decompressed.bin\""
+        if os.name == 'nt':
+            cmd = f"\"{self._file_dir}GZIP.EXE\" -dc \"{self._file_dir}Randomized_ROM/{compressed_file.upper()}-Compressed.bin\" > \"{self._file_dir}Randomized_ROM/{compressed_file.upper()}-Decompressed.bin\""
+        else:
+            cmd = f"gzip -dc \"{self._file_dir}Randomized_ROM/{compressed_file.upper()}-Compressed.bin\" > \"{self._file_dir}Randomized_ROM/{compressed_file.upper()}-Decompressed.bin\""
         subprocess.Popen(cmd, universal_newlines=True, shell=True).communicate()
     
     def _decompressor(self, id_dict, address_type="Pointer"):

--- a/Randomization_Processes/Misc_Manipulation/Texture_Data/Texture_Main.py
+++ b/Randomization_Processes/Misc_Manipulation/Texture_Data/Texture_Main.py
@@ -25,7 +25,7 @@ class Texture_Class():
         self._file_dir = file_dir
         self._address = address
         self._seed_val = seed_val
-        with open(f"{self._file_dir}Randomized_ROM\\{self._address}-Decompressed.bin", "r+b") as decomp_file:
+        with open(f"{self._file_dir}Randomized_ROM/{self._address}-Decompressed.bin", "r+b") as decomp_file:
 #         with open(f"{self._file_dir}{self._address}-Decompressed.bin", "r+b") as decomp_file:
             self.mm = mmap(decomp_file.fileno(), 0)
     
@@ -48,7 +48,7 @@ class Texture_Class():
                 "X_Length": self.mm[text_header_index + 8],
                 "Y_Length": self.mm[text_header_index + 9],
                 })
-            with open(f"{self._file_dir}Randomized_ROM\\{self._address}-Texture_{leading_zeros(str(texture_count), 3)}.bin", "w+b") as texture_file:
+            with open(f"{self._file_dir}Randomized_ROM/{self._address}-Texture_{leading_zeros(str(texture_count), 3)}.bin", "w+b") as texture_file:
                 for index in range(self._texture_list[-1]["Texture_Start"], self._texture_list[-1]["Texture_Start"] + (self._texture_list[-1]["X_Length"] * self._texture_list[-1]["Y_Length"])//2 + 0x20):
                     texture_file.write(bytes.fromhex(leading_zeros(self.mm[index], 2)))
             texture_count += 1

--- a/Randomization_Processes/Setup_Functions.py
+++ b/Randomization_Processes/Setup_Functions.py
@@ -37,7 +37,7 @@ from random import randint
 
 def setup_tmp_folder(file_dir):
     """Creates temporary folder that'll be used to store bin files and the randomized ROM."""
-    rando_rom_folder = f"{file_dir}Randomized_ROM\\"
+    rando_rom_folder = f"{file_dir}Randomized_ROM/"
     if(not os.path.isdir(rando_rom_folder)):
         os.mkdir(rando_rom_folder)
     else:
@@ -60,7 +60,7 @@ def set_seed(seed_val=None):
 
 def make_copy_of_rom(seed_val, file_dir, original_rom):
     """Creates a copy of the rom that will be used for randomization"""
-    randomized_rom_file = f"{file_dir}Randomized_ROM\\Banjo-Kazooie_Randomized_Seed_{str(seed_val)}.z64"
+    randomized_rom_file = f"{file_dir}Randomized_ROM/Banjo-Kazooie_Randomized_Seed_{str(seed_val)}.z64"
     shutil.copyfile(original_rom, randomized_rom_file)
     return randomized_rom_file
 

--- a/Randomization_Processes/World_Manipulation/World_Manipulation_Main.py
+++ b/Randomization_Processes/World_Manipulation/World_Manipulation_Main.py
@@ -1318,7 +1318,7 @@ class World_Manipulation_Class():
         # Find location of world puzzles
         # 00 00 01 01 00 5D 02 02 00 5E 05 03 00 60 07 03 00 63 08 04 00 66 09 04 00 6A 0A 04 00 6E 0C 04 00 72 0F 04 00 76 19 05 00 7A 04 03
         # Every 4 is a note door, with the third value being the one you have to change
-        with open(f"{self._file_dir}Randomized_ROM\\FCF698-Decompressed.bin", "r+b") as decomp_file:
+        with open(f"{self._file_dir}Randomized_ROM/FCF698-Decompressed.bin", "r+b") as decomp_file:
             mm_decomp = mmap.mmap(decomp_file.fileno(), 0)
             #                                                      0 1 2 3 4 5 6 7 8 910111213141516171819202122232425262728293031323334353637383940414243
             note_door_index_start = mm_decomp.find(bytes.fromhex("00000101005D0202005E0503006007030063080400660904006A0A04006E0C0400720F0400761905007A0403"))

--- a/User_GUI.py
+++ b/User_GUI.py
@@ -452,7 +452,7 @@ class User_GUI_Class():
     def _select_rom_file(self):
         '''Opens a browser to select the ROM file ending in .z64'''
         self.logger.info("Selecting ROM file")
-        filename = tkinter.filedialog.askopenfilename(initialdir=self.cwd, title="Select The BK ROM File", filetype =(("Rom Files","*.z64"),("all files","*.*")) )
+        filename = tkinter.filedialog.askopenfilename(initialdir=self.cwd, title="Select The BK ROM File", filetypes =(("Rom Files","*.z64"),("all files","*.*")) )
         if(not filename):
             return
         self.rom_file_entry.set(filename)

--- a/User_GUI.py
+++ b/User_GUI.py
@@ -400,7 +400,7 @@ class User_GUI_Class():
         self.logger = logging.getLogger("Rotating Log")
         self.logger.setLevel(logging.INFO)
         FORMAT = '[%(levelname)s] %(asctime)-15s - %(funcName)s: %(message)s'
-        handler = RotatingFileHandler(f"{self.cwd}\Randomizer_Log_File.log", maxBytes=(512*1024), backupCount=1)
+        handler = RotatingFileHandler(f"{self.cwd}/Randomizer_Log_File.log", maxBytes=(512*1024), backupCount=1)
         self.logger.addHandler(handler)
         logging.basicConfig(format=FORMAT)
     


### PR DESCRIPTION
These three commits fix some Windows dependencies in the Python scripts:

- One particular file dialog was passing `filetype`  instead of `filetypes`, which might have worked at one point but doesn't seem to anymore...?
- For non-NT systems, use the system gzip instead of the bundled GZIP.EXE. I intentionally did a copypaste of the gzip line to be absolutely sure that the Windows build was unaffected by this change.
- Swapped `\\` separators with `/`, unlike the gzip change this was applied directly to the existing lines since Windows should be okay with these!

It's not perfect (for some reason the `update_bottles_gif` callback is mangled), but it does run and generate randomized ROMs!

![Screenshot_20240524_212855](https://github.com/CyrusKashef/BK_Randomizer/assets/1396814/ace39e31-b828-4dec-911f-fdc706abec8a)